### PR TITLE
DeviceSignalService protocol

### DIFF
--- a/NeuroIDAdvancedDevice/AdvancedDevice.swift
+++ b/NeuroIDAdvancedDevice/AdvancedDevice.swift
@@ -18,10 +18,9 @@ protocol DeviceSignalService {
 }
 
 public class NeuroIDADV: NSObject, DeviceSignalService {
-    public static let shared = NeuroIDADV()
     
     public func getAdvancedDeviceSignal(_ apiKey: String, completion: @escaping (Result<String, Error>) -> Void) {
-           NeuroIDADV.getAPIKey(apiKey) { result in
+        NeuroIDADV.getAPIKey(apiKey) { result in
                switch result {
                case .success(let fAPiKey):
                    NeuroIDADV.retryAPICall(apiKey: fAPiKey, maxRetries: 3, delay: 2) { result in

--- a/NeuroIDAdvancedDevice/AdvancedDevice.swift
+++ b/NeuroIDAdvancedDevice/AdvancedDevice.swift
@@ -12,22 +12,26 @@ struct NIDResponse: Codable {
     let key: String
 }
 
-public class NeuroIDADV: NSObject {
-    public static func getAdvancedDeviceSignal(
-        _ apiKey: String,
-        completion: @escaping (Result<String, Error>) -> Void
-    ) {
-        getAPIKey(apiKey) { result in
-            switch result {
-            case .success(let fAPiKey):
-                retryAPICall(apiKey: fAPiKey, maxRetries: 3, delay: 2) { result in
-                    completion(result)
-                }
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
+/** Interface that allows for testing */
+protocol DeviceSignalService {
+    func getAdvancedDeviceSignal(_ apiKey: String, completion: @escaping (Result<String, Error>) -> Void)
+}
+
+public class NeuroIDADV: NSObject, DeviceSignalService {
+    public static let shared = NeuroIDADV()
+    
+    public func getAdvancedDeviceSignal(_ apiKey: String, completion: @escaping (Result<String, Error>) -> Void) {
+           NeuroIDADV.getAPIKey(apiKey) { result in
+               switch result {
+               case .success(let fAPiKey):
+                   NeuroIDADV.retryAPICall(apiKey: fAPiKey, maxRetries: 3, delay: 2) { result in
+                       completion(result)
+                   }
+               case .failure(let error):
+                   completion(.failure(error))
+               }
+           }
+       }
 
     internal static func getAPIKey(
         _ apiKey: String,


### PR DESCRIPTION
This allows for us to dependency inject a device signal service for testing. No change for implementing customers